### PR TITLE
Don't crash talking to ghost after world reload

### DIFF
--- a/mods/citadel_core/ghost.lua
+++ b/mods/citadel_core/ghost.lua
@@ -43,6 +43,9 @@ minetest.register_entity(cc.."ghost", {
 		
 		self._image_index = self._image_index + 1
 	end,
+	get_staticdata = function(self)
+		return minetest.serialize(self._images)
+	end,
 	on_activate = function(self, staticdata, dtime_s)
 	    self.object:set_texture_mod("^[opacity:100")
 		self.object:set_velocity({x=0,y=0.1,z=0})

--- a/mods/citadel_core/ghost.lua
+++ b/mods/citadel_core/ghost.lua
@@ -20,7 +20,7 @@ minetest.register_entity(cc.."ghost", {
 	_factor = 1,
 	_by_player = false,
 	on_rightclick = function(self, clicker)
-		if self._image_index > #self._images then
+		if (not self._image_index) or (self._image_index > #self._images) then
 			self._image_index = 1
 		end
 		


### PR DESCRIPTION
This _might_ also fix #19 - retesting needed.