### PR TITLE
Musicfix

### DIFF
--- a/mods/citadel_core/ambience.lua
+++ b/mods/citadel_core/ambience.lua
@@ -1,42 +1,74 @@
-local ambiance_handle
-local saved_id
+local player_state = {}
 
-local ducking
-function citadel.audio_duck(time)
-	if not ambiance_handle then return end
-	local my_ducking = {}
-	ducking = my_ducking
-	minetest.sound_fade(ambiance_handle, 1, citadel.sounds[saved_id].gain / 5)
-	minetest.after(time, function()
-		if my_ducking ~= ducking then return end -- replaced by another duck
-		minetest.sound_fade(ambiance_handle, 0.2, citadel.sounds[saved_id].gain)
-	end)
-end
-
-local start_time = 0
-minetest.register_globalstep(function(dtime)
-	start_time = start_time + dtime
-	-- Minetest doesn't like music start_time arbitrarily large
-	if start_time >= 864000 then start_time = start_time - 864000 end
+minetest.register_on_leaveplayer(function(player)
+	player_state[player:get_player_name()] = nil
 end)
 
---minetest.sound_play(spec, parameters, [ephemeral])
---minetest.sound_fade(handle, step, gain)
-function citadel.set_ambience(id)
-	saved_id = id
-	if ambiance_handle then
-		minetest.sound_fade(ambiance_handle, 0.2, 0)
+local function musiccheck(player)
+	local pname = player:get_player_name()
+
+	-- Start playing all 3 songs in loop immediately, and
+	-- we'll change songs by cross-fading them.
+	local state = player_state[pname]
+	if not state then
+		state = {}
+		for i, v in ipairs(citadel.sounds) do
+			state[i] =  {
+				id = minetest.sound_play(v.file, {
+					to_player = pname,
+					gain = 0.001,
+					loop = true,
+				}),
+				gain = 0.001
+			}
+		end
+		player_state[pname] = state
 	end
-	ambiance_handle = minetest.sound_play(citadel.sounds[id].file, {
-		to_player = "singleplayer",
-		gain = citadel.sounds[id].gain,
-		fade = 0.2,
-		pitch = 1.0,
-		loop = true,
-		start_time = citadel.sounds[id].offset and start_time or 0
-	}, false)
+
+	-- Figure out what song should be playing, and at what relative
+	-- volume, by searching for nearby ghosts.  Doing this statelessly
+	-- instead of requiring ghosts or other scripts to tell us what
+	-- to change the song to makes this more robust in the event of
+	-- unexpected modes of transition.
+	local ppos = player:get_pos()
+	local song = 1
+	local gain = 1
+	for _, ent in pairs(minetest.luaentities) do
+		if ent.name == cc.."ghost" then
+			if ent._images[1] == 50 then
+				song = 3
+				if ent._audio_duck_time then gain = 1/5 end
+			else
+				local pos = ent.object:get_pos()
+				if pos and vector.distance(pos, ppos) < 5 then
+					song = 2
+					if ent._audio_duck_time then gain = 1/5 end
+					break
+				end
+			end
+		end
+	end
+
+	-- Mute all songs other than the target one.  Change the target
+	-- song to the desired gain.
+	local function fadeto(stateobj, rate, target)
+		if stateobj.gain == target then return end
+		minetest.sound_fade(stateobj.id, rate, target)
+		stateobj.gain = target
+	end
+	for i, v in pairs(state) do
+		if song ~= i then
+			fadeto(v, 0.2, 0.001)
+		elseif gain == 1 then
+			fadeto(v, 0.2, citadel.sounds[i].gain)
+		else
+			fadeto(v, 2, citadel.sounds[i].gain * gain)
+		end
+	end
 end
 
-minetest.register_on_joinplayer(function(ObjectRef, last_login)
-	citadel.set_ambience(1)
+minetest.register_globalstep(function()
+	for _, player in pairs(minetest.get_connected_players()) do
+		musiccheck(player)
+	end
 end)

--- a/mods/citadel_core/functions.lua
+++ b/mods/citadel_core/functions.lua
@@ -306,5 +306,4 @@ function citadel.endgame()
 	minetest.after(2, function(player) player:set_pos({x=3,y=-40,z=3}) end, player)
 	data:set_string("ended", "yes")
 	minetest.sound_play("crack", {to_player = "singleplayer"}, true)
-	citadel.set_ambience(3)
 end

--- a/mods/citadel_core/ghost.lua
+++ b/mods/citadel_core/ghost.lua
@@ -64,7 +64,7 @@ minetest.register_entity(cc.."ghost", {
 		end
 		ghost_sound_ids = {}
 
-		citadel.audio_duck(dia_timing[diaid])
+		self._audio_duck_time = dia_timing[diaid]
  
 		-- Play ghost sounds with a spread out spatial effect
 		-- (start_time in MT 5.8+) for a more other-worldy effect
@@ -96,7 +96,6 @@ minetest.register_entity(cc.."ghost", {
 			minetest.after(8, function()
 				local player = minetest.get_player_by_name("singleplayer")
 				player:set_pos(minetest.deserialize(data:get_string("endpos")))
-				citadel.set_ambience(1)
 			end)
 		end
 		
@@ -112,6 +111,12 @@ minetest.register_entity(cc.."ghost", {
 		self.object:set_armor_groups({immortal = 1})
 	end,
 	on_step = function(self, dtime_s)
+		if self._audio_duck_time then
+			self._audio_duck_time = self._audio_duck_time - dtime_s
+			if self._audio_duck_time <= 0 then
+				self._audio_duck_time = nil
+			end
+		end
 		
 		self._anim_timer = self._anim_timer + dtime_s*self._factor
 		if self._anim_timer > 2 then
@@ -120,26 +125,15 @@ minetest.register_entity(cc.."ghost", {
 		end
 
 		local objects = minetest.get_objects_inside_radius(self.object:get_pos(), 5)
-		local by_player = false
 		for o=1, #objects do
 			local obj = objects[o]
 			if obj and obj:is_player() then
-				by_player = true
 				local dir = vector.direction(self.object:get_pos(),obj:get_pos())
 				local yaw = minetest.dir_to_yaw(dir)
 				if yaw then
 					self.object:set_yaw(yaw)
 					break
 				end
-			end
-		end
-		if data:get_string("ended") == "" then
-			if by_player and not self._by_player then
-				self._by_player = true
-				citadel.set_ambience(2)
-			elseif not by_player and self._by_player then
-				self._by_player = false
-				citadel.set_ambience(1)
 			end
 		end
 	end,

--- a/mods/citadel_core/ghost.lua
+++ b/mods/citadel_core/ghost.lua
@@ -87,13 +87,13 @@ minetest.register_entity(cc.."ghost", {
 
 		--endgame stuff
 		if diaid == 50 then
-			minetest.after(4, function(self) 
+			minetest.after(5, function(self) 
 				self._factor = 0
-				self.object:set_velocity({x=0,y=10,z=0}) 
+				self.object:set_velocity({x=0,y=10,z=0})
 			end, self)
-			minetest.after(5, function(self) self.object:remove() end, self)
-			minetest.after(7, function() citadel.hud("white", "white_hud.png") end)
-			minetest.after(8, function()
+			minetest.after(6, function() minetest.clear_objects() end)
+			minetest.after(8, function() citadel.hud("white", "white_hud.png") end)
+			minetest.after(9, function()
 				local player = minetest.get_player_by_name("singleplayer")
 				player:set_pos(minetest.deserialize(data:get_string("endpos")))
 			end)


### PR DESCRIPTION
Fixes #23 

Fixes #26 

N.B. the ghost theme(s) no longer start at the beginning when transitioning in; I don't see any reason to believe this is a problem.  Especially for the normal (non-endgame) ghost theme, players seem likely to get fatigued hearing the start of the song each time, similar for the normal no-ghost background theme.

Also includes a couple small fixes for the endgame, including having ghosts left over until the player time-travels at least once in the "clear" game.