### PR TITLE
Add a basic RTA-based speedrun timer

### DIFF
--- a/mods/citadel_timer/init.lua
+++ b/mods/citadel_timer/init.lua
@@ -1,0 +1,104 @@
+local string_format, math_floor = string.format, math.floor
+
+local modstore = minetest.get_mod_storage()
+
+-- Keep track of the number of play sessions.
+local sessions = modstore:get_int("sessions") or 0
+sessions = sessions + 1
+modstore:set_int("sessions", sessions)
+
+-- Keep track of whether timer is frozen due to endgame.
+local endgame = modstore:get_string("endgame")
+if endgame == "" then endgame = nil end
+
+-- Monkey-patch the ghost so that the final ghost, which starts the
+-- endgame sequence, freezes the timer as soon as you talk to it.
+-- This is the last meaningful control input from the player.
+do
+	local ghost = minetest.registered_entities["citadel_core:ghost"]
+	if not ghost then error("ghost entity registration not found") end
+	local oldclick = ghost.on_rightclick
+	ghost.on_rightclick = function(self, ...)
+		local diaid = self._images[self._image_index]
+		if diaid == 50 and not endgame then
+			endgame = true
+			modstore:set_string("endgame", "1")
+		end
+		return oldclick(self, ...)
+	end
+end
+
+-- Keep track of total play time.
+local timer = modstore:get_float("timer") or 0
+
+-- Stub for updating HUDs, which is enabled only if the speedrun
+-- setting is enabled at startup (there is no value in supporting
+-- toggling it at runtime as runs would be invalid anyway).
+local function updatehuds() end
+if minetest.settings:get_bool("citadel_speedrun") then
+	-- Utility function to format time in sexagesimal.
+	local function timefmt(n)
+		local s = string_format("%0.3f", n % 60)
+		if n < 60 then return s end
+		if (n % 60) < 10 then s = "0" .. s end
+		local m = math_floor(n / 60)
+		if m < 60 then return m .. ":" .. s end
+		local h = math_floor(m / 60)
+		m = m % 60
+		m = (m < 10) and ("0" .. m) or ("" .. m)
+		return h .. ":" .. m .. ":" .. s
+	end
+
+	local huds = {}
+	updatehuds = function()
+		-- Show timer, with [sessions] prefixed if the number of
+		-- sessions is not 1 (it should always be 1 for valid runs).
+		local text = ((sessions ~= 1) and ("[" .. sessions .. "] ") or "")
+		.. timefmt(timer)
+		-- Add/update all player HUD text.
+		for _, player in ipairs(minetest.get_connected_players()) do
+			local pname = player:get_player_name()
+			local hud = huds[pname]
+			if not hud then
+				hud = {
+					id = player:hud_add({
+							hud_elem_type = "text",
+							position = {x = 1, y = 0},
+							alignment = {x = -1, y = 1},
+							offset = {x = -4, y = 4},
+							text = text,
+							number = 0xffffffff,
+							style = 5,
+							z_index = 1100
+						}),
+					text = text,
+				}
+				huds[pname] = hud
+			end
+			if hud.text ~= text then
+				player:hud_change(hud.id, "text", text)
+				hud.text = text
+			end
+		end
+	end
+	-- Invalidate HUD cache of players who leave.
+	minetest.register_on_leaveplayer(function(player)
+			huds[player:get_player_name()] = nil
+		end)
+end
+
+-- Update timer and HUDs every step.
+do
+	local prevtick
+	local get_us_time = minetest.get_us_time
+	minetest.register_globalstep(function()
+			local now = get_us_time() / 1000000
+			if not prevtick then prevtick = now end
+			if not endgame then
+				timer = timer + now - prevtick
+				prevtick = now
+				modstore:set_float("timer", timer)
+			end
+			updatehuds()
+		end)
+end

--- a/mods/citadel_timer/mod.conf
+++ b/mods/citadel_timer/mod.conf
@@ -1,0 +1,2 @@
+name = citadel_timer
+depends = citadel_core

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,2 +1,5 @@
 # Ambient light level
 light_level (Ambient Light Level) int 4
+
+# Enable the built-in speedrunning timer
+citadel_speedrun (Enable Citadel speedrun timer) bool false


### PR DESCRIPTION
- Implemented as a separate mod to avoid further cluttering the monolithic core mod.
- Play time, session count, and endgame freeze are always tracked.
- Time is tracked during pauses as well (RTA rules).
- A setting (default off) enables displaying the timer.
- The timer is displayed in a text HUD in the upper right corner of the screen in sexagesimal format.
- If play session count is not exactly 1, it's displayed in brackets (speedrun category rules may require exactly 1 session).
- Timing starts when the server first starts ticking, and ends when the player right-clicks the final ghost (last meaningful input).
- The timer HUD is white, which fits the game's visual theme reasonbly well, while standing out against the black sky much of the time, especially after right-clicking the last ghost.  It blends in with some white brickwork and the credits screen but this is probably not enough of a problem.

Resolves #53 