### PR TITLE
Add volume controls for music and voice

### DIFF
--- a/mods/citadel_core/ambience.lua
+++ b/mods/citadel_core/ambience.lua
@@ -1,3 +1,6 @@
+local musicvol = tonumber(minetest.settings:get("citadel_volume_music")) or 1
+if musicvol <= 0 then return end
+
 local player_state = {}
 local data = minetest.get_mod_storage()
 
@@ -57,6 +60,7 @@ local function musiccheck(player)
 	-- Mute all songs other than the target one.  Change the target
 	-- song to the desired gain.
 	local function fadeto(stateobj, time, target)
+		target = target * musicvol
 		if stateobj.gain == target then
 			return
 		end

--- a/mods/citadel_core/ghost.lua
+++ b/mods/citadel_core/ghost.lua
@@ -1,3 +1,5 @@
+local voicevol = tonumber(minetest.settings:get("citadel_volume_voice")) or 1
+
 local data = minetest.get_mod_storage()
 local dia_timing = {
 	[1] = 6.170,
@@ -67,22 +69,24 @@ minetest.register_entity("citadel_core:" .. "ghost", {
 
 		self._audio_duck_time = dia_timing[diaid]
 
-		-- Play ghost sounds with a spread out spatial effect
-		-- (start_time in MT 5.8+) for a more other-worldy effect
-		local qty = 3
-		local offs = math.random() * math.pi * 2
-		for i = 1, qty do
-			ghost_sound_ids[minetest.sound_play("dia" .. diaid, {
-				pos = vector.offset(
-					self.object:get_pos(),
-					math.sin(i * 2 / qty * math.pi + offs) * 2,
-					1.8,
-					math.cos(i * 2 / qty * math.pi + offs) * 2
-				),
-				gain = 2,
-				start_time = i / qty * 0.05,
-			})] =
-				true
+		if voicevol > 0 then
+			-- Play ghost sounds with a spread out spatial effect
+			-- (start_time in MT 5.8+) for a more other-worldy effect
+			local qty = 3
+			local offs = math.random() * math.pi * 2
+			for i = 1, qty do
+				ghost_sound_ids[minetest.sound_play("dia" .. diaid, {
+					pos = vector.offset(
+						self.object:get_pos(),
+						math.sin(i * 2 / qty * math.pi + offs) * 2,
+						1.8,
+						math.cos(i * 2 / qty * math.pi + offs) * 2
+					),
+					gain = 2 * voicevol,
+					start_time = i / qty * 0.05,
+				})] =
+					true
+			end
 		end
 
 		local img = "text_overlay.png^dia" .. diaid .. ".png^[colorize:#ffffff:200"

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,2 +1,8 @@
 # Ambient light level
 light_level (Ambient Light Level) int 4
+
+# Volume of Citadel in-game music
+citadel_volume_music (Music volume) float 1
+
+# Volume of Citadel in-game voices
+citadel_volume_voice (Voice volume) float 1


### PR DESCRIPTION
If either volume is set to <= 0 then don't play the sounds at all, so MT doesn't even load the sound files.

Resolves #56