### PR TITLE
Standardize item inventory slots

### DIFF
--- a/mods/citadel_core/functions.lua
+++ b/mods/citadel_core/functions.lua
@@ -429,3 +429,25 @@ function citadel.show_credits()
 	end
 	citadel.hud("credits", credits, 10)
 end
+
+do
+	local old_drops = minetest.handle_node_drops
+	function minetest.handle_node_drops(pos, drops, digger, ...)
+		local inv = digger and digger:get_inventory()
+		if not digger then return old_drops(pos, drops, digger, ...) end
+		local skipped = {}
+		local dirty
+		for k, item in pairs(drops) do
+			local name = ItemStack(item):get_name()
+			local def = name and minetest.registered_items[name]
+			local slot = def and def._citadel_inv_slot
+			if slot then
+				inv:set_stack("main", slot, name)
+			else
+				skipped[k] = item
+				dirty = true
+			end
+		end
+		if dirty then return old_drops(pos, skipped, digger, ...) end
+	end
+end

--- a/mods/citadel_core/guidence.lua
+++ b/mods/citadel_core/guidence.lua
@@ -3,6 +3,7 @@ minetest.register_craftitem("citadel_core:" .. "letter", {
 	description = "Letter",
 	inventory_image = "letter_inv.png",
 	stack_max = 1,
+	_citadel_inv_slot = 9,
 	on_use = function(itemstack, user, pointed_thing)
 		minetest.show_formspec(
 			"singleplayer",
@@ -73,6 +74,7 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 	end
 end)
 minetest.register_craftitem("citadel_core:" .. "book", {
+	_citadel_inv_slot = 10,
 	description = "Journal",
 	inventory_image = "book_inv.png",
 	stack_max = 1,

--- a/mods/citadel_core/guidence.lua
+++ b/mods/citadel_core/guidence.lua
@@ -4,6 +4,7 @@ minetest.register_craftitem("citadel_core:" .. "letter", {
 	inventory_image = "letter_inv.png",
 	stack_max = 1,
 	_citadel_inv_slot = 9,
+	_citadel_inv_initial = true,
 	on_use = function(itemstack, user, pointed_thing)
 		minetest.show_formspec(
 			"singleplayer",
@@ -74,10 +75,11 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 	end
 end)
 minetest.register_craftitem("citadel_core:" .. "book", {
-	_citadel_inv_slot = 10,
 	description = "Journal",
 	inventory_image = "book_inv.png",
 	stack_max = 1,
+	_citadel_inv_slot = 10,
+	_citadel_inv_initial = true,
 	on_use = function(itemstack, user, pointed_thing)
 		local last_dug = minetest.get_player_by_name("singleplayer"):get_meta():get_string("last_dug")
 		local page = 1

--- a/mods/citadel_core/mapgen.lua
+++ b/mods/citadel_core/mapgen.lua
@@ -41,9 +41,16 @@ minetest.register_on_joinplayer(function(player)
 	})
 	player:set_physics_override({ jump = 1.1 })
 	player:set_properties({ textures = { "blank.png" } })
-	player:hud_set_hotbar_itemcount(10)
-	--make sure you don't end up with permanently activated stones
+	local maxslot = 0;
+	for _, v in pairs(minetest.registered_items) do
+		if v._citadel_inv_slot and v._citadel_inv_slot > maxslot then
+			maxslot = v._citadel_inv_slot
+		end
+	end
 	local inv = player:get_inventory()
+	inv:set_size("main", maxslot)
+	player:hud_set_hotbar_itemcount(maxslot)
+	--make sure you don't end up with permanently activated stones
 	for _, stone_name in pairs({ "foward", "backward", "unlock", "break" }) do
 		if inv:contains_item("main", "citadel_core:" .. stone_name .. "_stone_active") then
 			for i = 1, inv:get_size("main") do

--- a/mods/citadel_core/mapgen.lua
+++ b/mods/citadel_core/mapgen.lua
@@ -96,8 +96,16 @@ minetest.register_on_newplayer(function(player)
 	sepia_hud_create(player)
 	citadel.change_time_period(5)
 	player:set_pos({ x = 40, y = 7, z = -5 })
-	player:get_inventory():set_stack("main", 1, "citadel_core:" .. "letter")
-	player:get_inventory():set_stack("main", 2, "citadel_core:" .. "book")
+	local inv = player:get_inventory()
+	for name, def in pairs(minetest.registered_items) do
+		if def._citadel_inv_initial then
+			if def._citadel_inv_slot then
+				inv:set_stack("main", def._citadel_inv_slot, name)
+			else
+				inv:add_item("main", name)
+			end
+		end
+	end
 	player:get_meta():set_int("page", 1)
 end)
 

--- a/mods/citadel_core/plants.lua
+++ b/mods/citadel_core/plants.lua
@@ -14,6 +14,7 @@ minetest.register_node("citadel_core:" .. "acorn", {
 	walkable = false,
 	tiles = { brown, dark_brown },
 	groups = { cracky = 2, breakable = 1, unique = 1 },
+	_citadel_inv_slot = 6,
 	after_place_node = function(pos, placer, itemstack, pointed_thing)
 		pos.y = pos.y - 1
 		if
@@ -42,6 +43,7 @@ minetest.register_node("citadel_core:" .. "big_acorn", {
 	walkable = false,
 	tiles = { brown, dark_brown },
 	groups = { cracky = 2, breakable = 1, unique = 1 },
+	_citadel_inv_slot = 5,
 	after_place_node = function(pos, placer, itemstack, pointed_thing)
 		pos.y = pos.y - 1
 		if
@@ -70,6 +72,7 @@ minetest.register_node("citadel_core:" .. "vine_bud", {
 	tiles = { green },
 	walkable = false,
 	groups = { cracky = 2, breakable = 1, unique = 1 },
+	_citadel_inv_slot = 8,
 	after_place_node = function(pos, placer, itemstack, pointed_thing)
 		pos.y = pos.y + 1
 		if
@@ -108,6 +111,7 @@ minetest.register_node("citadel_core:" .. "bamboo_shoot", {
 	walkable = false,
 	tiles = { dark_green },
 	groups = { cracky = 2, breakable = 1, unique = 1 },
+	_citadel_inv_slot = 7,
 	after_place_node = function(pos, placer, itemstack, pointed_thing)
 		pos.y = pos.y - 1
 		if

--- a/mods/citadel_core/stones.lua
+++ b/mods/citadel_core/stones.lua
@@ -5,6 +5,7 @@ minetest.register_craftitem("citadel_core:" .. "foward_stone", {
 	description = "Stone of the Future",
 	inventory_image = "small_stone.png^(foward_overlay.png^[colorize:black)",
 	stack_max = 1,
+	_citadel_inv_slot = 2,
 	on_use = function(itemstack, user, pointed_thing)
 		if citadel.go_foward() then
 			local inv = user:get_inventory()
@@ -20,6 +21,7 @@ minetest.register_craftitem("citadel_core:" .. "foward_stone_active", {
 	description = "Stone of the Future",
 	inventory_image = "small_stone.png^foward_overlay.png",
 	stack_max = 1,
+	_citadel_inv_slot = 2,
 })
 minetest.register_node("citadel_core:" .. "foward_stone_node", {
 	description = "fsn",
@@ -33,6 +35,7 @@ minetest.register_node("citadel_core:" .. "foward_stone_node", {
 		type = "wallmounted",
 	},
 	drop = "citadel_core:" .. "foward_stone",
+	_citadel_inv_slot = 2,
 	_on_unique = citadel.unique_item("citadel_core:" .. "foward_stone", "citadel_core:" .. "foward_stone_active"),
 })
 --backward stone
@@ -40,6 +43,7 @@ minetest.register_craftitem("citadel_core:" .. "backward_stone", {
 	description = "Stone of the Past",
 	inventory_image = "small_stone.png^(backward_overlay.png^[colorize:black)",
 	stack_max = 1,
+	_citadel_inv_slot = 1,
 	on_use = function(itemstack, user, pointed_thing)
 		if citadel.go_backward() then
 			local inv = user:get_inventory()
@@ -55,6 +59,7 @@ minetest.register_craftitem("citadel_core:" .. "backward_stone_active", {
 	description = "Stone of the Past",
 	inventory_image = "small_stone.png^(backward_overlay.png)",
 	stack_max = 1,
+	_citadel_inv_slot = 1,
 })
 minetest.register_node("citadel_core:" .. "backward_stone_node", {
 	description = "bsn",
@@ -68,6 +73,7 @@ minetest.register_node("citadel_core:" .. "backward_stone_node", {
 		type = "wallmounted",
 	},
 	drop = "citadel_core:" .. "backward_stone",
+	_citadel_inv_slot = 1,
 	_on_unique = citadel.unique_item("citadel_core:" .. "backward_stone", "citadel_core:" .. "backward_stone_active"),
 })
 --unlock stone
@@ -135,6 +141,7 @@ minetest.register_craftitem("citadel_core:" .. "unlock_stone", {
 	description = "Stone of Unbarring",
 	inventory_image = "small_stone.png^(unlock.png^[colorize:black)",
 	stack_max = 1,
+	_citadel_inv_slot = 3,
 	on_use = function(itemstack, user, pointed_thing)
 		if pointed_thing.type == "node" and unbar(pointed_thing.under) then
 			local inv = user:get_inventory()
@@ -150,6 +157,7 @@ minetest.register_craftitem("citadel_core:" .. "unlock_stone_active", {
 	description = "Stone of Unsealing",
 	inventory_image = "small_stone.png^(unlock.png)",
 	stack_max = 1,
+	_citadel_inv_slot = 3,
 })
 minetest.register_node("citadel_core:" .. "unlock_stone_node", {
 	description = "usn",
@@ -163,6 +171,7 @@ minetest.register_node("citadel_core:" .. "unlock_stone_node", {
 		type = "wallmounted",
 	},
 	drop = "citadel_core:" .. "unlock_stone",
+	_citadel_inv_slot = 3,
 	_on_unique = citadel.unique_item("citadel_core:" .. "unlock_stone", "citadel_core:" .. "unlock_stone_active"),
 })
 
@@ -171,6 +180,7 @@ minetest.register_craftitem("citadel_core:" .. "break_stone", {
 	description = "Stone of Destruction",
 	inventory_image = "small_stone.png^(break.png^[colorize:black)",
 	stack_max = 1,
+	_citadel_inv_slot = 4,
 	on_use = function(itemstack, user, pointed_thing)
 		if
 			pointed_thing.type == "object"


### PR DESCRIPTION
Each item is assigned to its own inventory slot, and goes into that specific inventory slot when acquired.

Benefits:

- Automatically mitigates item duplication glitches.  If a player acquires the same stone a second time, it will overwrite the existing copy instead of occupying another inventory slot.
- Players cannot rearrange their inventory, so this makes the hotkeys for each item consistent across plays, rather than being dependent on item acquisition order.  This is similar to how first person shooters assign each weapon to a numbered hotkey slot at design-time instead of runtime.
- Items can be organized into categories: stones, then plants, then guidance.  Putting the guidance last makes it less obtrusive for more experienced players, while still easily accessible for new players.

This also makes a couple of architectural improvements:

- The inventory and hotbar size can be set automatically based on the assigned slots, so it will automatically be consistent if items are added/removed.
- We can also drive which items you start with by definitions.