### PR TITLE
Fix collision precision issues

### DIFF
--- a/mods/citadel_core/functions.lua
+++ b/mods/citadel_core/functions.lua
@@ -189,9 +189,19 @@ end
 
 function citadel.check_player_collided(player)
 	local pos = player:get_pos()
-	for dy = 0, 1.9 do
-		for dx = -0.3, 0.3, 0.6 do
-			for dz = -0.3, 0.3, 0.6 do
+	local hitbox = player:get_properties().collisionbox
+	local function bounds(a, b)
+		a = hitbox[a] + 0.01
+		b = hitbox[b] - 0.01
+		local c = math.ceil(b - a)
+		return a, b, (b - a) / c
+	end
+	local minx, maxx, stepx = bounds(1, 4)
+	local miny, maxy, stepy = bounds(2, 5)
+	local minz, maxz, stepz = bounds(3, 6)
+	for dy = miny, maxy, stepy do
+		for dx = minx, maxx, stepx do
+			for dz = minz, maxz, stepz do
 				local p = vector.offset(pos, dx, dy, dz)
 				if minetest.get_node(p).name ~= "air" then
 					return true


### PR DESCRIPTION
Since updating the engine from 5.10 to 5.12, somewhere along the way, the player's exact positioning and collision mechanics seem to have changed, so that checking exactly +/- 0.3, to match the player's default collison box size, now rounds into the adjacent wall instead of staying outside, for at least some corners.  This causes a player to be unable to change time period when snugly pressed into at least certain corners.  Add a very small collision tolerance to make this work correctly again, which in principle SHOULD still be enough to prevent teleporting into collison.